### PR TITLE
Enable editing project type

### DIFF
--- a/apps/frontend/src/pages/[type]/[id].vue
+++ b/apps/frontend/src/pages/[type]/[id].vue
@@ -1375,6 +1375,15 @@ async function patchProject(resData, quiet = false) {
       project.value[key] = resData[key];
     }
 
+    if (resData.project_type) {
+      project.value.actualProjectType = resData.project_type;
+      project.value.project_type = data.$getProjectTypeForUrl(
+        resData.project_type,
+        project.value.loaders,
+        tags.value,
+      );
+    }
+
     if (resData.license_id) {
       project.value.license.id = resData.license_id;
     }

--- a/apps/frontend/src/pages/[type]/[id]/settings/index.vue
+++ b/apps/frontend/src/pages/[type]/[id]/settings/index.vue
@@ -79,6 +79,20 @@
         />
       </div>
 
+      <label for="project-type">
+        <span class="label__title">Project Type</span>
+      </label>
+      <select
+        id="project-type"
+        v-model="projectType"
+        :disabled="!hasPermission"
+      >
+        <option value="mod">Mod</option>
+        <option value="modpack">Modpack</option>
+        <option value="datapack">Datapack</option>
+        <option value="plugin">Plugin</option>
+      </select>
+
       <label for="project-summary">
         <span class="label__title">Summary</span>
       </label>
@@ -279,6 +293,7 @@ const router = useNativeRouter();
 const name = ref(props.project.title);
 const slug = ref(props.project.slug);
 const summary = ref(props.project.description);
+const projectType = ref(props.project.actualProjectType);
 const icon = ref(null);
 const previewImage = ref(null);
 const clientSide = ref(props.project.client_side);
@@ -310,6 +325,9 @@ const patchData = computed(() => {
   }
   if (slug.value !== props.project.slug) {
     data.slug = slug.value.trim();
+  }
+  if (projectType.value !== props.project.actualProjectType) {
+    data.project_type = projectType.value;
   }
   if (summary.value !== props.project.description) {
     data.description = summary.value.trim();

--- a/apps/labrinth/src/models/v3/projects.rs
+++ b/apps/labrinth/src/models/v3/projects.rs
@@ -20,6 +20,8 @@ pub struct Project {
     pub id: ProjectId,
     /// The slug of a project, used for vanity URLs
     pub slug: Option<String>,
+    /// The primary project type
+    pub project_type: String,
     /// The aggregated project typs of the versions of this project
     pub project_types: Vec<String>,
     /// The aggregated games of the versions of this project
@@ -139,6 +141,7 @@ impl From<ProjectQueryResult> for Project {
         Self {
             id: m.id.into(),
             slug: m.slug,
+            project_type: data.project_type,
             project_types: data.project_types,
             games: data.games,
             team_id: m.team_id.into(),

--- a/apps/labrinth/src/routes/v2/projects.rs
+++ b/apps/labrinth/src/routes/v2/projects.rs
@@ -376,6 +376,7 @@ pub struct EditProject {
     pub license_id: Option<String>,
     pub client_side: Option<LegacySideType>,
     pub server_side: Option<LegacySideType>,
+    pub project_type: Option<String>,
     #[validate(
         length(min = 3, max = 64),
         regex(path = *crate::util::validate::RE_URL_SAFE)
@@ -512,6 +513,7 @@ pub async fn project_edit(
         moderation_message_body: v2_new_project.moderation_message_body,
         monetization_status: v2_new_project.monetization_status,
         side_types_migration_review_status: None, // Not to be exposed in v2
+        project_type: v2_new_project.project_type,
     };
 
     // This returns 204 or failure so we don't need to do anything with it


### PR DESCRIPTION
## Summary
- allow selecting project type in project settings
- send `project_type` with project patch requests
- update frontend state on project type change
- support editing project type in backend routes

## Testing
- `cargo check` *(fails: DATABASE_URL not set)*
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686672c39e1c832585d859dc17b37a5d