### PR TITLE
Fix compile errors after project_type changes

### DIFF
--- a/apps/labrinth/src/database/models/project_item.rs
+++ b/apps/labrinth/src/database/models/project_item.rs
@@ -208,6 +208,7 @@ impl ProjectBuilder {
             license_url: self.license_url,
             license: self.license,
             slug: self.slug,
+            project_type: self.project_type,
             moderation_message: None,
             moderation_message_body: None,
             webhook_sent: false,
@@ -791,7 +792,7 @@ impl DBProject {
                     LEFT JOIN categories c ON mc.joining_category_id = c.id
                     LEFT JOIN project_types pt ON pt.id = m.project_type
                     WHERE m.id = ANY($1) OR m.slug = ANY($2)
-                    GROUP BY t.id, m.id;
+                    GROUP BY t.id, m.id, pt.name;
                     ",
                     &project_ids_parsed,
                     &slugs,
@@ -833,9 +834,7 @@ impl DBProject {
                                 status: ProjectStatus::from_string(
                                     &m.status,
                                 ),
-                                requested_status: m.requested_status.map(|x| ProjectStatus::from_string(
-                                    &x,
-                                )),
+                                requested_status: m.requested_status.map(|x| ProjectStatus::from_string(x)),
                                 license: m.license.clone(),
                                 slug: m.slug.clone(),
                                 project_type: m.project_type.clone(),

--- a/apps/labrinth/src/routes/v3/project_creation.rs
+++ b/apps/labrinth/src/routes/v3/project_creation.rs
@@ -173,6 +173,9 @@ pub struct ProjectCreateData {
     #[serde(alias = "mod_slug")]
     /// The slug of a project, used for vanity URLs
     pub slug: String,
+    #[serde(default = "default_project_type")]
+    /// The project type of this mod
+    pub project_type: String,
     #[validate(length(min = 3, max = 255))]
     #[serde(alias = "mod_description")]
     /// A short description of the project.
@@ -760,6 +763,8 @@ async fn project_create_inner(
             icon_url: icon_data.clone().map(|x| x.0),
             raw_icon_url: icon_data.clone().map(|x| x.1),
 
+            project_type: project_create_data.project_type.clone(),
+
             license_url: project_create_data.license_url,
             categories,
             additional_categories,
@@ -861,6 +866,7 @@ async fn project_create_inner(
         let response = crate::models::projects::Project {
             id: project_id,
             slug: project_builder.slug.clone(),
+            project_type: project_create_data.project_type.clone(),
             project_types,
             games,
             team_id: team_id.into(),


### PR DESCRIPTION
## Summary
- update group by for project type
- fill project_type field when building a project
- accept project_type in project creation
- return project_type in project creation response

## Testing
- `cargo check --color never` *(fails: rustfmt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686681781f4c83258fd1e2706741209b