### PR TITLE
Fix compile issues in labrinth

### DIFF
--- a/apps/labrinth/src/database/models/project_item.rs
+++ b/apps/labrinth/src/database/models/project_item.rs
@@ -834,7 +834,10 @@ impl DBProject {
                                 status: ProjectStatus::from_string(
                                     &m.status,
                                 ),
-                                requested_status: m.requested_status.map(|x| ProjectStatus::from_string(x)),
+                                requested_status: m
+                                    .requested_status
+                                    .as_deref()
+                                    .map(ProjectStatus::from_string),
                                 license: m.license.clone(),
                                 slug: m.slug.clone(),
                                 project_type: m.project_type.clone(),

--- a/apps/labrinth/src/routes/v2/project_creation.rs
+++ b/apps/labrinth/src/routes/v2/project_creation.rs
@@ -228,6 +228,7 @@ pub async fn project_create(
                 slug: legacy_create.slug,
                 summary: legacy_create.description, // Description becomes summary
                 description: legacy_create.body,    // Body becomes description
+                project_type,
                 initial_versions,
                 categories: legacy_create.categories,
                 additional_categories: legacy_create.additional_categories,


### PR DESCRIPTION
## Summary
- fix `requested_status` type to match ProjectStatus parsing
- include `project_type` when converting V2 project creation to V3

## Testing
- `SQLX_OFFLINE=true cargo check -p labrinth --quiet` *(fails: no cached query data)*

------
https://chatgpt.com/codex/tasks/task_e_68668a93766c8325a85984e76363c2f8